### PR TITLE
Update npr_cds.php to show CPT in REST API

### DIFF
--- a/npr_cds.php
+++ b/npr_cds.php
@@ -264,6 +264,7 @@ function npr_cds_create_post_type(): void {
 		],
 		'description' => 'Stories pulled from NPR or member stations via the NPR CDS',
 		'public' => true,
+		'show_in_rest' => true,
 		'menu_position' => 5,
 		'menu_icon' => 'dashicons-admin-post',
 		'has_archive' => true,


### PR DESCRIPTION
Allows for consumption via REST API, namely, allowing for block editing experience.