### PR TITLE
Add support for byline profiles on pulled stories

### DIFF
--- a/classes/NPR_CDS_WP.php
+++ b/classes/NPR_CDS_WP.php
@@ -288,7 +288,7 @@ class NPR_CDS_WP {
 							}
 						}
 					}
-					if ( !empty( $bylines ) ) {
+					if ( !empty( $by_lines ) ) {
 						$by_line = $by_lines[0]['name'];
 						if ( count( $by_lines ) > 1 ) {
 							$all_bylines = [];

--- a/classes/NPR_CDS_WP.php
+++ b/classes/NPR_CDS_WP.php
@@ -279,6 +279,12 @@ class NPR_CDS_WP {
 										'link' => $byl_link
 									];
 								}
+							} else {
+								if (!empty($byl_current->name)) {
+									$by_lines[] = [
+										'name' => $byl_current->name
+									];
+								}
 							}
 						}
 					}


### PR DESCRIPTION
## Summary

- parses bylines with profiles other than reference-byline (closes #9)

## Testing

- Pull a story using the reference-byline profile (e.g., 1240718749). Names should be stored in `npr_byline`, and byline links should be stored in `npr_byline_link`.
- Pull a story using multiple byline profiles (e.g., 1240454899). Primary author should be stored in `npr_byline`, and full list of names should be stored in `npr_multi_byline`.