### PR TITLE
fix for broken Update link in stories column

### DIFF
--- a/get_stories.php
+++ b/get_stories.php
@@ -286,7 +286,7 @@ class NPR_CDS {
 			$retrieved = get_post_meta( $post_ID, NPR_RETRIEVED_STORY_META_KEY, true );
 			if ( $retrieved ) {
 				$api_id = get_post_meta( $post_ID, NPR_STORY_ID_META_KEY, TRUE );
-				echo npr_cds_esc_html( '<a href="' . admin_url( 'edit.php?page=get-npr-stories&story_id=' .$api_id ) . '"> Update </a>' );
+				echo npr_cds_esc_html( '<a href="' . admin_url( 'edit.php?post_type=' . $this->get_pull_post_type() . '&page=get-npr-stories&story_id=' .$api_id ) . '"> Update </a>' );
 			}
 		}
 	}


### PR DESCRIPTION
"Update" link in right column would give a permissions error since it didn't include a post_type.  