### PR TITLE
check for optional audio enclosure rels before using

### DIFF
--- a/classes/NPR_CDS_WP.php
+++ b/classes/NPR_CDS_WP.php
@@ -1024,7 +1024,7 @@ class NPR_CDS_WP {
 								$body_with_layout .= '<p><iframe class="npr-embed-audio" style="width: 100%; height: 239px;" src="' . $asset_current->embeddedPlayerLink->href . '"></iframe></p>';
 							} elseif ( $asset_current->isDownloadable ) {
 								foreach ( $asset_current->enclosures as $enclose ) {
-									if ( $enclose->type == 'audio/mpeg' && !in_array( 'premium', $enclose->rels ) ) {
+									if ( $enclose->type == 'audio/mpeg' && empty($enclose->rels) || !in_array( 'premium', $enclose->rels ) ) {
 										$body_with_layout .= '[audio mp3="' . $enclose->href . '"][/audio]';
 									}
 								}


### PR DESCRIPTION
## Summary

- adds a check for empty enclosure rels before searching the array (closes #21)

## Testing

0. Switch CDS settings to pull from staging server.
1. Create a post using story ID `ipmee-00000-standard`, which contains audio with no rels property on the enclosure.
    - No exception should be thrown.
    - Audio should be available in the new post.
2. Create a post using story ID `ipmee-00000-premium`, which contains premium audio.
    - No exception should be thrown.
    - No audio should be available in the new post.