### PR TITLE
fix fatal when a collection has no rels

### DIFF
--- a/classes/NPR_CDS_WP.php
+++ b/classes/NPR_CDS_WP.php
@@ -635,6 +635,9 @@ class NPR_CDS_WP {
 				}
 				if ( !empty( $story->collections ) && $import_tags === '1' ) {
 					foreach ( $story->collections as $collect ) {
+						if ( !isset( $collect->rels ) ) {
+							continue;
+						}
 						if ( in_array( 'topic', $collect->rels ) || in_array( 'category', $collect->rels ) ) {
 
 							/**


### PR DESCRIPTION
There's a situation I was seeing where a query was returning collections that had no 'rels'.   It was consistently causing fatals in my environment.  This code adds a check for rels to be set before attempting to do an in_array against it.