### PR TITLE
Add filter hook for customizing bylines before CDS conversion

### DIFF
--- a/classes/npr_json.php
+++ b/classes/npr_json.php
@@ -157,6 +157,10 @@ function npr_cds_to_json( $post ): bool|string {
 	} else {
 		npr_cds_error_log( 'can not find get_coauthors' );
 	}
+
+	// last chance to customize bylines before converting to CDS format
+	$bylines = apply_filters( 'npr_cds_bylines_filter', $bylines, $post->ID );
+
 	if ( empty( $bylines ) ) {
 		$bylines[] = get_the_author_meta( 'display_name', $post->post_author );
 	}


### PR DESCRIPTION
## Summary
We have authors as custom post type,  `npr_cds_bylines_filter` allows customization of bylines before they are converted to CDS format.

## Changes
- Added `npr_cds_bylines_filter` hook in `npr_cds_to_json()` function

## Use Case
To  modify bylines before get sent to NPR.

## Example Usage
```php
add_filter( 'npr_cds_bylines_filter', function( $bylines, $post_id ) {
    // Custom byline modification logic here
    return $bylines;
}, 10, 2 );